### PR TITLE
Add unit tests for com.sia.hunter.helper.OnlineTaskHelper

### DIFF
--- a/sia-task-hunter/pom.xml
+++ b/sia-task-hunter/pom.xml
@@ -86,7 +86,33 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>1.6.5</version>
+			<scope>test</scope>
+		</dependency>
 
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>1.6.5</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/sia-task-hunter/src/main/test/com/sia/hunter/OnlineTaskHelperTest.java
+++ b/sia-task-hunter/src/main/test/com/sia/hunter/OnlineTaskHelperTest.java
@@ -1,0 +1,68 @@
+package com.sia.hunter;
+
+import com.sia.hunter.helper.OnlineTaskHelper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+
+@RunWith(PowerMockRunner.class)
+public class OnlineTaskHelperTest {
+
+  @PrepareForTest(RequestMethod.class)
+  @Test
+  public void testCheckRequestMethod() {
+    final RequestMethod requestMethod1 = PowerMockito.mock(RequestMethod.class);
+
+    Assert.assertFalse(OnlineTaskHelper.checkRequestMethod(null));
+    Assert.assertFalse(OnlineTaskHelper.
+            checkRequestMethod(new RequestMethod[]{requestMethod1}));
+
+    Assert.assertTrue(OnlineTaskHelper.
+            checkRequestMethod(new RequestMethod[]{}));
+  }
+
+  @Test
+  public void testCheckReturnType() {
+    Assert.assertFalse(OnlineTaskHelper.checkReturnType(null));
+  }
+
+  @Test
+  public void testCheckParameterTypes() {
+    Assert.assertEquals(-1, OnlineTaskHelper.checkParameterTypes(null));
+    Assert.assertEquals(0,
+            OnlineTaskHelper.checkParameterTypes(new Class[]{}));
+    Assert.assertEquals(-1,
+            OnlineTaskHelper.checkParameterTypes(new Class[]{null}));
+    Assert.assertEquals(-1,
+            OnlineTaskHelper.checkParameterTypes(new Class[]{null, null}));
+  }
+
+  @Test
+  public void testCheckHttpPath() {
+    Assert.assertFalse(OnlineTaskHelper.checkHttpPath(""));
+    Assert.assertFalse(OnlineTaskHelper.checkHttpPath(" "));
+  }
+
+  @Test
+  public void testEncodeHttpPath() {
+    Assert.assertEquals("", OnlineTaskHelper.encodeHttpPath(""));
+    Assert.assertEquals(" ", OnlineTaskHelper.encodeHttpPath(" "));
+  }
+
+  @Test
+  public void testToList() {
+    Assert.assertEquals(Arrays.asList("-100"),
+            OnlineTaskHelper.toList(new Object[]{-100}));
+    Assert.assertEquals(new LinkedList<String>(),
+            OnlineTaskHelper.toList(new Object[]{}));
+    Assert.assertEquals(new LinkedList<String>(),
+            OnlineTaskHelper.toList(null));
+  }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.sia.hunter.helper.OnlineTaskHelper` is not fully tested. I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.